### PR TITLE
feat: ssh command support

### DIFF
--- a/modules/serverstate/serverstate_sgmod.js
+++ b/modules/serverstate/serverstate_sgmod.js
@@ -100,13 +100,13 @@ module.exports = {
     }
 
     async function sendSshCommand(server, command) {
-      let output = null;
-      let sshClient;
-
       // Sanity check
       if (!sshCmdAllowlist.includes(command)) {
-        return output;
+        return null;
       }
+
+      let sshClient;
+      let output = null;
 
       try {
         sshClient = new NodeSSH();
@@ -124,16 +124,30 @@ module.exports = {
 
         if (command === "details") {
           fullCommand = "TERM=xterm-256color " + fullCommand
-            + `details | grep Status | tail -1 | awk -F':\t' '{print $2}' | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,3})*)?[mGK]//g"`;
+            + `details | grep Status | tail -1 | awk -F':\\t' '{print $2}'`;
         } else {
           fullCommand += command;
         }
 
+        fullCommand += ` | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,3})*)?[mGK]//g"`;
+
         console.log(`[SSH] Executing command on ${server.name}: ${fullCommand}`);
 
-        output = await sshClient.execCommand(fullCommand, { cwd: `/home/${server.sshUsername}` });
+        commandResult = await sshClient.execCommand(fullCommand, { cwd: `/home/${server.sshUsername}` });
 
-        console.log(`[SSH] Response from ${server.name}: ${JSON.stringify(output)}`);
+        console.log(`[SSH] Response from ${server.name}: ${JSON.stringify(commandResult)}`);
+
+        output = {
+          status: commandResult.code,
+          message: ""
+        };
+
+        if (commandResult.code != 0 && commandResult.stdout.length === 0) {
+          output.message = commandResult.stderr;
+        } else {
+          const splitStdout = commandResult.stdout.split('\r');
+          output.message = splitStdout[splitStdout.length - 1];
+        }
       } catch (error) {
         console.error(`[SSH] Error sending command to ${server.name}:`, error);
       } finally {

--- a/modules/serverstate/serverstate_sgmod.js
+++ b/modules/serverstate/serverstate_sgmod.js
@@ -4,6 +4,7 @@ const express = require('express');
 require('dotenv').config();
 const { Rcon } = require('rcon-client');
 const axios = require('axios');
+const { NodeSSH } = require('node-ssh');
 
 module.exports = {
   meta: {
@@ -18,6 +19,8 @@ module.exports = {
     let channelServers = {};
     // Map for the RCON endpoint (keyed by ip:port)
     let serverAddressMap = {};
+    // List of allowable SSH commands
+    let sshCmdAllowlist = ['start', 'stop', 'update', 'details'];
 
     let hardcodedChannelIds = [];
     let publicChannelIds = []; // New array for channels using PublicChannelId
@@ -45,7 +48,9 @@ module.exports = {
             name: server.name, 
             ip, 
             port: parseInt(port), 
-            password: server.rconPassword 
+            password: server.rconPassword,
+            sshUsername: server.machineUsername,
+            sshPassword: server.machinePassword
           };
 
           // Use matchroomId as the key for channelServers (for message handling)
@@ -93,8 +98,55 @@ module.exports = {
         }
       }
     }
-    
 
+    async function sendSshCommand(server, command) {
+      let output = null;
+      let sshClient;
+
+      // Sanity check
+      if (!sshCmdAllowlist.includes(command)) {
+        return output;
+      }
+
+      try {
+        sshClient = new NodeSSH();
+
+        await sshClient.connect({
+          host: server.ip,
+          port: 22,
+          username: server.sshUsername,
+          password: server.sshPassword
+        });
+
+        console.log(`[SSH] Connection established to ${server.name}`);
+
+        let fullCommand = "./cs2server ";
+
+        if (command === "details") {
+          fullCommand = "TERM=xterm-256color " + fullCommand
+            + `details | grep Status | tail -1 | awk -F':\t' '{print $2}' | sed -r "s/\\x1B\\[([0-9]{1,3}(;[0-9]{1,3})*)?[mGK]//g"`;
+        } else {
+          fullCommand += command;
+        }
+
+        console.log(`[SSH] Executing command on ${server.name}: ${fullCommand}`);
+
+        output = await sshClient.execCommand(fullCommand, { cwd: `/home/${server.sshUsername}` });
+
+        console.log(`[SSH] Response from ${server.name}: ${JSON.stringify(output)}`);
+      } catch (error) {
+        console.error(`[SSH] Error sending command to ${server.name}:`, error);
+      } finally {
+        try {
+          sshClient?.dispose();
+        } catch (err) {
+          console.error(`[SSH] Error closing connection to ${server.name}:`, err);
+        }
+      }
+
+      return output;
+    }
+    
     // **Middleware for API Key Authentication**
     function authenticateApiKey(req, res, next) {
       const requestApiKey = req.headers['x-api-key'];
@@ -146,6 +198,40 @@ module.exports = {
         }
       }
     }
+
+    // **Expose an SSH API Endpoint with API Key Protection**
+    app.post('/ssh', authenticateApiKey, async (req, res) => {
+      const { ip, port, command } = req.body;
+
+      if (!ip || !port || !command) {
+        return res.status(400).json({ error: 'Missing required parameters: ip, port, or command' });
+      }
+
+      if (!sshCmdAllowlist.includes(command)) {
+        return res.status(400).json({ error: 'Invalid SSH command' });
+      }
+
+      const serverKey = `${ip}:${port}`;
+      const server = serverAddressMap[serverKey];
+
+      if (!server) {
+        return res.status(404).json({ error: 'Server not found for the provided IP and port' });
+      }
+
+      console.log(`[SERVERSTATE MODULE] Received SSH request for ${server.name} -> ${command}`);
+
+      let responseData = await sendSshCommand(server, command);
+
+      if (responseData === "") {
+        responseData = "No Message";
+      }
+
+      if (responseData) {
+        return res.json({ success: true, response: responseData });
+      } else {
+        return res.status(500).json({ success: false, error: 'Failed to execute SSH command' });
+      }
+    });
 
     // **Start HTTPS Server with PFX Certificate**
     https.createServer(options, app).listen(3001, '0.0.0.0', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "express": "^4.18.2",
         "pg": "^8.11.1",
         "pg-promise": "^11.5.0",
-        "rcon-client": "^4.2.5"
+        "rcon-client": "^4.2.5",
+        "ssh2": "^1.16.0"
       },
       "devDependencies": {
         "eslint": "^8.45.0",
@@ -525,6 +526,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
     "node_modules/assert-options": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/assert-options/-/assert-options-0.8.1.tgz",
@@ -568,6 +578,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
     "node_modules/body-parser": {
       "version": "1.20.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
@@ -608,6 +627,15 @@
       "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/buildcheck": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.6.tgz",
+      "integrity": "sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/builtins": {
@@ -779,6 +807,20 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2465,6 +2507,13 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/nan": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
+      "integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3288,6 +3337,23 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/ssh2": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.16.0.tgz",
+      "integrity": "sha512-r1X4KsBGedJqo7h8F5c4Ybpcr5RjyP+aWIG007uBPRjmdQWfEiVLzSK71Zji1B9sKxwaCvD8y8cwSkYrlLiRRg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.10",
+        "nan": "^2.20.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -3475,6 +3541,12 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
       "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,10 @@
         "discord.js": "^14.11.0",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
+        "node-ssh": "^13.2.1",
         "pg": "^8.11.1",
         "pg-promise": "^11.5.0",
-        "rcon-client": "^4.2.5",
-        "ssh2": "^1.16.0"
+        "rcon-client": "^4.2.5"
       },
       "devDependencies": {
         "eslint": "^8.45.0",
@@ -2255,6 +2255,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
@@ -2414,6 +2426,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -2526,6 +2553,23 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-ssh": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/node-ssh/-/node-ssh-13.2.1.tgz",
+      "integrity": "sha512-rfl4GWMygQfzlExPkQ2LWyya5n2jOBm5vhEnup+4mdw7tQhNpJWbP5ldr09Jfj93k5SfY5lxcn8od5qrQ/6mBg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-stream": "^2.0.0",
+        "make-dir": "^3.1.0",
+        "sb-promise-queue": "^2.1.0",
+        "sb-scandir": "^3.1.0",
+        "shell-escape": "^0.2.0",
+        "ssh2": "^1.14.0"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/object-inspect": {
@@ -3159,11 +3203,31 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/sb-promise-queue": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/sb-promise-queue/-/sb-promise-queue-2.1.1.tgz",
+      "integrity": "sha512-qXfdcJQMxMljxmPprn4Q4hl3pJmoljSCzUvvEBa9Kscewnv56n0KqrO6yWSrGLOL9E021wcGdPa39CHGKA6G0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/sb-scandir": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/sb-scandir/-/sb-scandir-3.1.1.tgz",
+      "integrity": "sha512-Q5xiQMtoragW9z8YsVYTAZcew+cRzdVBefPbb9theaIKw6cBo34WonP9qOCTKgyAmn/Ch5gmtAxT/krUgMILpA==",
+      "license": "MIT",
+      "dependencies": {
+        "sb-promise-queue": "^2.1.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -3248,6 +3312,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/shell-escape": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/shell-escape/-/shell-escape-0.2.0.tgz",
+      "integrity": "sha512-uRRBT2MfEOyxuECseCZd28jC1AJ8hmqqneWQ4VWUTgCAFvb3wKU1jLqj6egC4Exrr88ogg3dp+zroH4wJuaXzw==",
+      "license": "MIT"
     },
     "node_modules/side-channel": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "discord.js": "^14.11.0",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "node-ssh": "^13.2.1",
     "pg": "^8.11.1",
     "pg-promise": "^11.5.0",
-    "rcon-client": "^4.2.5",
-    "ssh2": "^1.16.0"
+    "rcon-client": "^4.2.5"
   },
   "devDependencies": {
     "eslint": "^8.45.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "express": "^4.18.2",
     "pg": "^8.11.1",
     "pg-promise": "^11.5.0",
-    "rcon-client": "^4.2.5"
+    "rcon-client": "^4.2.5",
+    "ssh2": "^1.16.0"
   },
   "devDependencies": {
     "eslint": "^8.45.0",


### PR DESCRIPTION
Added a new `POST /ssh` endpoint which accepts a body similar to the existing `POST /rcon` endpoint to enable execution of certain commands on the gameserver through SSH. Currently only supports LinuxGSM commands for installs located in the home directory of the user associated with that specific Nexus server entry. Currently only supports the following LinuxGSM commands: `start`, `stop`, `update`,`details`.